### PR TITLE
Give write permissions to labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   labeler:
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository


### PR DESCRIPTION
Trying to fix the actions workflow error: 
```
🏃 Running GitHub Labeler
🎨 Creating 'breaking' label with color 'bfd4f2' and desc 'Breaking Changes'
Error: Cannot create "breaking" label: Resource not accessible by integration
```